### PR TITLE
Fix weird behavior in IIR filter bank/analog-style analyzer

### DIFF
--- a/Rendering.cpp
+++ b/Rendering.cpp
@@ -228,7 +228,7 @@ void UIElement::Process() noexcept
     }
     else
     {
-        const bool IsSlidingWindow = (_ThreadState._Transform == Transform::SWIFT);
+        const bool IsSlidingWindow = (_ThreadState._Transform == Transform::SWIFT) || (_ThreadState._Transform == Transform::AnalogStyle);
 
         const double WindowSize = IsSlidingWindow ? PlaybackTime - _ThreadState._PlaybackTime : (double) _ThreadState._BinCount / (double) _ThreadState._SampleRate;
         const double Offset     = IsSlidingWindow ?                _ThreadState._PlaybackTime : PlaybackTime - (WindowSize * (0.5 + _ThreadState._ReactionAlignment));


### PR DESCRIPTION
Right now, this IIR filter bank analyzer on this foobar2000 component behave strangely though [my own CodePen project about filter bank analyzers](https://codepen.io/TF3RDL/pen/MWLzPoO) exhibit this same weird behavior when getFloatTimeDomainData is used instead of AudioWorklet on this aforementioned CodePen project

So, this change should correct this behavior