### PR TITLE
Enable spectrum analyzer component to run under Wine

### DIFF
--- a/Support.h
+++ b/Support.h
@@ -1,5 +1,5 @@
 
-/** $VER: Support.h (2026.03.01) P. Stuer **/
+/** $VER: Support.h (2026.07.22) P. Stuer **/
 
 #pragma once
 
@@ -13,6 +13,17 @@
 HRESULT InitializeDpiAwareness() noexcept;
 HRESULT GetDPI(_In_ HWND hWnd, _Out_ UINT & dpi) noexcept;
 HRESULT EvaluateTitleFormatScript(_In_ const std::wstring & script, _Out_ pfc::string & result) noexcept;
+
+/// <summary>
+/// Determines whether the component is running under Wine/Proton by probing for the
+/// `wine_get_version()` export that Wine adds to its "ntdll" implementation.
+/// </summary>
+inline bool IsWineOrProton() noexcept
+{
+    const HMODULE hNTDLL = ::GetModuleHandleW(L"ntdll.dll");
+
+    return (hNTDLL != nullptr) && (::GetProcAddress(hNTDLL, "wine_get_version") != nullptr);
+}
 
 /// <summary>
 /// Converts magnitude to decibel (dB).

--- a/UIElement.cpp
+++ b/UIElement.cpp
@@ -1,5 +1,5 @@
 
-/** $VER: UIElement.cpp (2026.06.08) P. Stuer - UIElement methods that run on the UI thread. **/
+/** $VER: UIElement.cpp (2026.07.22) P. Stuer - UIElement methods that run on the UI thread. **/
 
 #include "pch.h"
 
@@ -18,7 +18,7 @@
 /// <summary>
 /// Initializes a new instance.
 /// </summary>
-uielement_t::uielement_t(): _IsFullScreen(false), _IsVisible(true), _IsInitializing(true), _hParent(), _DPI(), _DisplayRefreshRate(), _hStopRendering(), _hThread(), _TrackingGraph(), _TrackingToolInfo(), _LastMousePos(), _LastBandIndex(~0U)
+uielement_t::uielement_t(): _IsFullScreen(false), _IsVisible(true), _IsInitializing(true), _hParent(), _DPI(), _DisplayRefreshRate(), _IsWineOrProton(false), _hStopRendering(), _hThread(), _TrackingGraph(), _TrackingToolInfo(), _LastMousePos(), _LastBandIndex(~0U)
 {
 }
 

--- a/UIElement.h
+++ b/UIElement.h
@@ -1,5 +1,5 @@
 
-/** $VER: UIElement.h (2026.03.21) P. Stuer **/
+/** $VER: UIElement.h (2026.07.22) P. Stuer **/
 
 #pragma once
 
@@ -187,6 +187,7 @@ private:
 
     UINT _DPI;
     double _DisplayRefreshRate;
+    bool _IsWineOrProton;
 
     // Device-independent resources.
     CComPtr<ID2D1Factory1> _D2DFactory;

--- a/UIElementRendering.cpp
+++ b/UIElementRendering.cpp
@@ -1,5 +1,5 @@
 
-/** $VER: UIElementRendering.cpp (2026.07.04) P. Stuer - UIElement methods that run on the render thread. **/
+/** $VER: UIElementRendering.cpp (2026.07.22) P. Stuer - UIElement methods that run on the render thread. **/
 
 #include "pch.h"
 
@@ -343,7 +343,10 @@ HRESULT uielement_t::CreateDeviceIndependentResources() noexcept
     if (SUCCEEDED(hr))
         hr = ::D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr, Flags, nullptr, 0, D3D11_SDK_VERSION, &_D3DDevice, nullptr, &_D3DDeviceContext);
 
-    if (SUCCEEDED(hr))
+    _IsWineOrProton = IsWineOrProton();
+
+    // DirectComposition is not fully supported under Wine/Proton and causes the component to render blank.
+    if (SUCCEEDED(hr) && !_IsWineOrProton)
         hr = ::DCompositionCreateDevice(nullptr, __uuidof(IDCompositionDevice), reinterpret_cast<void **>(&_DCompositionDevice));
 
     hr = _FrameCounter.CreateDeviceIndependentResources();
@@ -418,7 +421,7 @@ HRESULT uielement_t::CreateDeviceSpecificResources() noexcept
 
         if (_SwapChain == nullptr)
         {
-            const DXGI_SWAP_CHAIN_DESC1 scd =
+            DXGI_SWAP_CHAIN_DESC1 scd =
             {
                 .Width       = Width,
                 .Height      = Height,
@@ -431,38 +434,51 @@ HRESULT uielement_t::CreateDeviceSpecificResources() noexcept
                 .AlphaMode   = DXGI_ALPHA_MODE_PREMULTIPLIED, // Required for alpha transparency.
             };
 
-            hr = _DXGIFactory->CreateSwapChainForComposition(_D3DDevice, &scd, nullptr, &_SwapChain);
+            // Prefer a composition swap chain presented through DirectComposition to enable transparent backgrounds.
+            if (!_IsWineOrProton)
+            {
+                hr = _DXGIFactory->CreateSwapChainForComposition(_D3DDevice, &scd, nullptr, &_SwapChain);
 
-            if (!SUCCEEDED(hr))
-                return hr;
-        }
+                // Set up DirectComposition.
+                if (SUCCEEDED(hr))
+                    hr = _DCompositionDevice->CreateTargetForHwnd(m_hWnd, TRUE, &_Target);
 
-        // Set up DirectComposition.
-        {
-            hr = _DCompositionDevice->CreateTargetForHwnd(m_hWnd, TRUE, &_Target);
+                if (SUCCEEDED(hr))
+                    hr = _DCompositionDevice->CreateVisual(&_Visual);
 
-            if (!SUCCEEDED(hr))
-                return hr;
+                if (SUCCEEDED(hr))
+                    hr = _Visual->SetContent(_SwapChain);
 
-            hr = _DCompositionDevice->CreateVisual(&_Visual);
+                if (SUCCEEDED(hr))
+                    hr = _Target->SetRoot(_Visual);
 
-            if (!SUCCEEDED(hr))
-                return hr;
+                if (SUCCEEDED(hr))
+                    hr = _DCompositionDevice->Commit();
 
-            hr = _Visual->SetContent(_SwapChain);
+                if (!SUCCEEDED(hr))
+                {
+                    _Visual.Release();
+                    _Target.Release();
+                    _SwapChain.Release();
+                }
+            }
 
-            if (!SUCCEEDED(hr))
-                return hr;
+            // Fall back to a windowed swap chain.
+            if (_SwapChain == nullptr)
+            {
+                scd.AlphaMode = DXGI_ALPHA_MODE_IGNORE; // Composition alpha is not available for a windowed swap chain.
 
-            hr = _Target->SetRoot(_Visual);
+                hr = _DXGIFactory->CreateSwapChainForHwnd(_D3DDevice, m_hWnd, &scd, nullptr, nullptr, &_SwapChain);
 
-            if (!SUCCEEDED(hr))
-                return hr;
+                if (!SUCCEEDED(hr))
+                    return hr;
 
-            hr = _DCompositionDevice->Commit();
+                // A window created with `WS_EX_NOREDIRECTIONBITMAP` has no redirection surface and would stay blank without DirectComposition.
+                const LONG_PTR ExStyle = ::GetWindowLongPtr(m_hWnd, GWL_EXSTYLE);
 
-            if (!SUCCEEDED(hr))
-                return hr;
+                if ((ExStyle & WS_EX_NOREDIRECTIONBITMAP) != 0)
+                    ::SetWindowLongPtr(m_hWnd, GWL_EXSTYLE, ExStyle & ~WS_EX_NOREDIRECTIONBITMAP);
+            }
         }
 
         if (_BackBuffer == nullptr)

--- a/Visuals/Artwork.cpp
+++ b/Visuals/Artwork.cpp
@@ -1,5 +1,5 @@
 
-/** $VER: Artwork.cpp (2026.06.10) P. Stuer **/
+/** $VER: Artwork.cpp (2026.07.22) P. Stuer **/
 
 #include "pch.h"
 
@@ -7,6 +7,7 @@
 
 #include "WIC.h"
 #include "ColorThief.h"
+#include "Support.h"
 
 #include <State.h>
 #include <Constants.h>
@@ -169,7 +170,8 @@ void artwork_t::Render(ID2D1DeviceContext * deviceContext, const D2D1_RECT_F & r
 
     AdjustRect(state->_FitMode, Scalar, Rect);
 
-    if (state->_ArtworkBlurSigma == 0.f)
+    // When the blur effect chain is unavailable (e.g. under Wine/Proton), fall back to a plain bitmap draw. This still honors the opacity but loses the blur.
+    if ((state->_ArtworkBlurSigma == 0.f) || !_HasEffects)
     {
         deviceContext->DrawBitmap(_Bitmap, Rect, state->_ArtworkOpacity, D2D1_BITMAP_INTERPOLATION_MODE::D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
     }
@@ -258,38 +260,45 @@ HRESULT artwork_t::CreateDeviceSpecificResources(ID2D1DeviceContext * deviceCont
         }
     }
 
-    if (_ScaleEffect == nullptr)
+    // Without a bitmap there is nothing to render or to attach effects to.
+    if (_Bitmap == nullptr)
+        return SUCCEEDED(hr) ? E_FAIL : hr;
+
+    // The Scale/GaussianBlur/Opacity effect chain is only used to render a blurred background. Direct2D effects are not (well) supported under
+    // Wine/Proton, so create them only when available and fall back to an unblurred DrawBitmap() (see Render()) otherwise.
+    if (!IsWineOrProton() && (_ScaleEffect == nullptr))
     {
         hr = deviceContext->CreateEffect(CLSID_D2D1Scale, &_ScaleEffect);
 
-        if (!SUCCEEDED(hr))
-            return hr;
+        if (SUCCEEDED(hr))
+            hr = deviceContext->CreateEffect(CLSID_D2D1GaussianBlur, &_BlurEffect);
+
+        if (SUCCEEDED(hr))
+        {
+            _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION, D2D1_DIRECTIONALBLUR_OPTIMIZATION_QUALITY);
+            _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD);
+
+            _BlurEffect->SetInputEffect(0, _ScaleEffect);
+
+            hr = deviceContext->CreateEffect(CLSID_D2D1Opacity, &_OpacityEffect);
+        }
+
+        if (SUCCEEDED(hr))
+        {
+            _OpacityEffect->SetInputEffect(0, _BlurEffect);
+        }
+        else
+        {
+            // Effects unavailable. Release any partial chain and render without blur.
+            _OpacityEffect.Release();
+            _BlurEffect.Release();
+            _ScaleEffect.Release();
+        }
     }
 
-    if (_BlurEffect == nullptr)
-    {
-        hr = deviceContext->CreateEffect(CLSID_D2D1GaussianBlur, &_BlurEffect);
+    _HasEffects = (_ScaleEffect != nullptr) && (_BlurEffect != nullptr) && (_OpacityEffect != nullptr);
 
-        if (!SUCCEEDED(hr))
-            return hr;
-
-        _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION, D2D1_DIRECTIONALBLUR_OPTIMIZATION_QUALITY);
-        _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD);
-
-        _BlurEffect->SetInputEffect(0, _ScaleEffect);
-    }
-
-    if (_OpacityEffect == nullptr)
-    {
-        hr = deviceContext->CreateEffect(CLSID_D2D1Opacity, &_OpacityEffect);
-
-        if (!SUCCEEDED(hr))
-            return hr;
-
-        _OpacityEffect->SetInputEffect(0, _BlurEffect);
-    }
-
-    return hr;
+    return S_OK;
 }
 
 /// <summary>

--- a/Visuals/Artwork.h
+++ b/Visuals/Artwork.h
@@ -1,5 +1,5 @@
 
-/** $VER: Artwork.h (2026.06.10) P. Stuer  **/
+/** $VER: Artwork.h (2026.07.22) P. Stuer  **/
 
 #pragma once
 
@@ -20,7 +20,7 @@
 class artwork_t
 {
 public:
-    artwork_t()
+    artwork_t() : _HasEffects(false)
     {
         SetStatus(Idle);
     }
@@ -83,6 +83,8 @@ private:
     CComPtr<ID2D1Effect> _ScaleEffect;
     CComPtr<ID2D1Effect> _BlurEffect;
     CComPtr<ID2D1Effect> _OpacityEffect;
+
+    bool _HasEffects;
 
     Status _Status;
 };

--- a/Visuals/Oscilloscope/Oscilloscope.cpp
+++ b/Visuals/Oscilloscope/Oscilloscope.cpp
@@ -1,5 +1,5 @@
 
-/** $VER: Oscilloscope.cpp (2026.07.04) P. Stuer - Implements an oscilloscope. **/
+/** $VER: Oscilloscope.cpp (2026.07.22) P. Stuer - Implements an oscilloscope. **/
 
 #include <pch.h>
 
@@ -161,7 +161,7 @@ void oscilloscope_t::Render(ID2D1DeviceContext * deviceContext) noexcept
         {
             _DeviceContext->BeginDraw();
 
-            if (_State->_HasPhosphorDecay)
+            if (_State->_HasPhosphorDecay && _HasEffects)
             {
                 _DeviceContext->SetTarget(_BackBuffer);
 

--- a/Visuals/Oscilloscope/OscilloscopeBase.cpp
+++ b/Visuals/Oscilloscope/OscilloscopeBase.cpp
@@ -1,9 +1,11 @@
 
-/** $VER: OscilloscopeBase.cpp (2026.06.21) P. Stuer - Implements a base class for an oscilloscope. **/
+/** $VER: OscilloscopeBase.cpp (2026.07.22) P. Stuer - Implements a base class for an oscilloscope. **/
 
 #include <pch.h>
 
 #include "OscilloscopeBase.h"
+
+#include "Support.h"
 
 #include "Direct2D.h"
 
@@ -12,7 +14,7 @@
 /// <summary>
 /// Initializes a new instance.
 /// </summary>
-oscilloscope_base_t::oscilloscope_base_t()
+oscilloscope_base_t::oscilloscope_base_t() : _HasEffects(false)
 {
 }
 
@@ -228,38 +230,54 @@ HRESULT oscilloscope_base_t::CreateDeviceSpecificResources(ID2D1DeviceContext * 
         _DeviceContext->SetTarget(nullptr);
     }
 
-    if (_BlurEffect == nullptr)
+    // Gaussian blur and color matrix effects for the phosphor decay simulation.
+    // `DrawImage()` for Direct2D effects is not fully supported under Wine/Proton (https://bugs.winehq.org/show_bug.cgi?id=59117).
+    if (_State->_HasPhosphorDecay && !IsWineOrProton())
     {
-        hr = _DeviceContext->CreateEffect(CLSID_D2D1GaussianBlur, &_BlurEffect);
-
-        if (!SUCCEEDED(hr))
-            return hr;
-
-        _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION, _State->_BlurSigma);
-        _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION, D2D1_DIRECTIONALBLUR_OPTIMIZATION_QUALITY);
-        _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD);
-    }
-
-    if (_ColorMatrixEffect == nullptr)
-    {
-        hr = _DeviceContext->CreateEffect(CLSID_D2D1ColorMatrix, &_ColorMatrixEffect);
-
-        if (!SUCCEEDED(hr))
-            return hr;
-
-        // Color matrix for uniform decay
-        #pragma warning(disable: 5246) // 'anonymous struct or union': the initialization of a subobject should be wrapped in braces
-        const D2D1_MATRIX_5X4_F DecayMatrix =
+        if (_BlurEffect == nullptr)
         {
-            _State->_DecayFactor, 0, 0, 0,  // Decay red
-            0, _State->_DecayFactor, 0, 0,  // Decay green
-            0, 0, _State->_DecayFactor, 0,  // Decay blue
-            0, 0, 0, 1,                     // Keep alpha
-            0, 0, 0, 0                      // Unused. Translation
-        };
+            hr = _DeviceContext->CreateEffect(CLSID_D2D1GaussianBlur, &_BlurEffect);
 
-        _ColorMatrixEffect->SetValue(D2D1_COLORMATRIX_PROP_COLOR_MATRIX, DecayMatrix);
+            if (SUCCEEDED(hr))
+            {
+                _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_STANDARD_DEVIATION, _State->_BlurSigma);
+                _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_OPTIMIZATION, D2D1_DIRECTIONALBLUR_OPTIMIZATION_QUALITY);
+                _BlurEffect->SetValue(D2D1_GAUSSIANBLUR_PROP_BORDER_MODE, D2D1_BORDER_MODE_HARD);
+            }
+        }
+
+        if (SUCCEEDED(hr) && (_ColorMatrixEffect == nullptr))
+        {
+            hr = _DeviceContext->CreateEffect(CLSID_D2D1ColorMatrix, &_ColorMatrixEffect);
+
+            if (SUCCEEDED(hr))
+            {
+                // Color matrix for uniform decay
+                #pragma warning(disable: 5246) // 'anonymous struct or union': the initialization of a subobject should be wrapped in braces
+                const D2D1_MATRIX_5X4_F DecayMatrix =
+                {
+                    _State->_DecayFactor, 0, 0, 0,  // Decay red
+                    0, _State->_DecayFactor, 0, 0,  // Decay green
+                    0, 0, _State->_DecayFactor, 0,  // Decay blue
+                    0, 0, 0, 1,                     // Keep alpha
+                    0, 0, 0, 0                      // Unused. Translation
+                };
+
+                _ColorMatrixEffect->SetValue(D2D1_COLORMATRIX_PROP_COLOR_MATRIX, DecayMatrix);
+            }
+        }
+
+        // If either effect could not be created, disable the phosphor decay path.
+        if (!SUCCEEDED(hr))
+        {
+            _ColorMatrixEffect.Release();
+            _BlurEffect.Release();
+
+            hr = S_OK;
+        }
     }
+
+    _HasEffects = (_BlurEffect != nullptr) && (_ColorMatrixEffect != nullptr);
 
 #ifdef _DEBUG
     if (_DebugBrush == nullptr)

--- a/Visuals/Oscilloscope/OscilloscopeBase.h
+++ b/Visuals/Oscilloscope/OscilloscopeBase.h
@@ -1,5 +1,5 @@
 
-/** $VER: OscilloscopeBase.h (2026.06.21) P. Stuer - Implements a base class for an oscilloscope. **/
+/** $VER: OscilloscopeBase.h (2026.07.22) P. Stuer - Implements a base class for an oscilloscope. **/
 
 #pragma once
 
@@ -55,4 +55,6 @@ protected:
 
     CComPtr<ID2D1Effect> _BlurEffect;
     CComPtr<ID2D1Effect> _ColorMatrixEffect;
+
+    bool _HasEffects;
 };

--- a/Visuals/Oscilloscope/OscilloscopeXY.cpp
+++ b/Visuals/Oscilloscope/OscilloscopeXY.cpp
@@ -1,5 +1,5 @@
 
-/** $VER: OscilloscopeXY.cpp (2026.07.04) P. Stuer - Implements an oscilloscope in X-Y mode. **/
+/** $VER: OscilloscopeXY.cpp (2026.07.22) P. Stuer - Implements an oscilloscope in X-Y mode. **/
 
 #include <pch.h>
 
@@ -154,7 +154,7 @@ void oscilloscope_xy_t::Render(ID2D1DeviceContext * deviceContext) noexcept
 
                 _DeviceContext->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
 
-                if (_State->_HasPhosphorDecay)
+                if (_State->_HasPhosphorDecay && _HasEffects)
                 {
                     _DeviceContext->SetTarget(_BackBuffer);
 


### PR DESCRIPTION
DirectComposition and Direct2D effects drawing are not fully supported under Wine/Proton, which leaves the component rendering blank. Detect that environment at runtime and degrade gracefully to supported APIs.

 - Add `IsWineOrProton()` which probes "ntdll" for the `wine_get_version()` export.
 - Skip DirectComposition setup under Wine. Fall back to  a windowed swap chain and clear `WS_EX_NOREDIRECTIONBITMAP`.
 - Guard the Scale/Gaussian Blur/Opacity/Color Matrix effect chains and fall back to `DrawBitmap()` when effects are unavailable.